### PR TITLE
optee backport fixes

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,7 +8,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "freescale-layer"
 BBFILE_PATTERN_freescale-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_freescale-layer = "5"
-LAYERSERIES_COMPAT_freescale-layer = "sumo thud"
+LAYERSERIES_COMPAT_freescale-layer = "sumo thud warrior"
 
 # Add the Freescale-specific licenses into the metadata
 LICENSE_PATH += "${LAYERDIR}/custom-licenses"

--- a/conf/machine/imx8mqevk.conf
+++ b/conf/machine/imx8mqevk.conf
@@ -51,6 +51,7 @@ UBOOT_MAKE_TARGET = ""
 IMX_BOOT_SEEK = "33"
 
 OPTEE_BIN_EXT = "8mq"
+OPTEE_PACKAGES = "optee-test-imx optee-client-imx"
 
 PREFERRED_PROVIDER_u-boot = "u-boot-imx"
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot-imx"

--- a/recipes-security/optee/optee-client-imx/0001-libteec-refactor-_dprintf.patch
+++ b/recipes-security/optee/optee-client-imx/0001-libteec-refactor-_dprintf.patch
@@ -1,0 +1,171 @@
+Upstream-Status: Backport
+
+Signed-off-by: Peter Griffin <peter.griffin@linaro.org>
+---
+From 0361f9b21bb1acfaf23323a121f542fe03dcd2c8 Mon Sep 17 00:00:00 2001
+From: Jerome Forissier <jerome.forissier@linaro.org>
+Date: Thu, 5 Jul 2018 15:15:31 +0200
+Subject: [PATCH] libteec: refactor _dprintf()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+GCC8.1 gives an error when compiling _dprintf():
+
+src/teec_trace.c: In function ‘_dprintf’:
+src/teec_trace.c:110:5: error: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size 246 [-Werror=format-truncation=]
+     "%s [%d] %s:%s:%d: %s",
+     ^~~~~~~~~~~~~~~~~~~~~~
+src/teec_trace.c:112:11:
+     line, raw);
+           ~~~
+src/teec_trace.c:109:3: note: ‘snprintf’ output 11 or more bytes (assuming 266) into a destination of size 256
+   snprintf(prefixed, MAX_PRINT_SIZE,
+   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     "%s [%d] %s:%s:%d: %s",
+     ~~~~~~~~~~~~~~~~~~~~~~~
+     trace_level_strings[level], thread_id, prefix, func,
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     line, raw);
+     ~~~~~~~~~~
+
+Fix this error by using a single output buffer, printing the prefix first
+then the other arguments with the supplied format.
+
+In addition, further simplify the function by getting rid of things that
+do not make much sense:
+- Remove the 'flen' parameter, which is only ever set to zero or
+  strlen(__func__).
+- Remove the TRACE_FUNC_LENGTH_CST macro which is not set by default and
+  does not seem very useful.
+- Change the return type to void because callers do not care about success
+  or failure.
+
+Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
+Reviewed-by: Joakim Bech <joakim.bech@linaro.org>
+---
+ libteec/src/teec_trace.c | 63 +++++++++++++++---------------------------------
+ public/teec_trace.h      |  8 +++---
+ 2 files changed, 23 insertions(+), 48 deletions(-)
+
+diff --git a/libteec/src/teec_trace.c b/libteec/src/teec_trace.c
+index 78b79d6..3a2a0da 100644
+--- a/libteec/src/teec_trace.c
++++ b/libteec/src/teec_trace.c
+@@ -47,7 +47,6 @@
+  * PPPP: MMMMM [FFFFFFFFFFFFFFF : LLLLL]
+  */
+ #define MAX_PRINT_SIZE 256
+-#define MAX_FUNC_PRINT_SIZE 32
+ 
+ #ifdef TEEC_LOG_FILE
+ static void log_to_file(const char *buffer)
+@@ -69,57 +68,33 @@ static const char * const trace_level_strings[] = {
+ 	"", "ERR", "INF", "DBG", "FLW"
+ };
+ 
+-int _dprintf(const char *function, int flen, int line, int level,
+-	     const char *prefix, const char *fmt, ...)
++void _dprintf(const char *function, int line, int level, const char *prefix,
++	      const char *fmt, ...)
+ {
+-	char raw[MAX_PRINT_SIZE];
+-	char prefixed[MAX_PRINT_SIZE];
+-	char *to_print = NULL;
+-	const char *func;
+-	int err;
++	char msg[MAX_PRINT_SIZE];
++	int n = 0;
+ 	va_list ap;
+ 
+-	va_start(ap, fmt);
+-	err = vsnprintf(raw, sizeof(raw), fmt, ap);
+-	va_end(ap);
+-
+ 	if (function) {
+-#ifdef TRACE_FUNC_LENGTH_CST
+-		char func_buf[MAX_FUNC_PRINT_SIZE];
+-		/* Limit the function name to MAX_FUNC_PRINT_SIZE characters. */
+-		strncpy(func_buf, function, flen > MAX_FUNC_PRINT_SIZE ?
+-			(MAX_FUNC_PRINT_SIZE - 1) : flen);
+-		if (flen < (MAX_FUNC_PRINT_SIZE - 1)) {
+-			memset(func_buf + flen, 0x20,
+-			       (MAX_FUNC_PRINT_SIZE - flen));
+-		}
+-		func_buf[MAX_FUNC_PRINT_SIZE - 1] = '\0';
+-		func = func_buf;
+-#else
+-		(void)flen;
+-		func = function;
+-#endif
++		int thread_id = syscall(SYS_gettid);
+ 
+-		/*
+-		 * pthread_self returns the POSIX tid which is different from
+-		 * the kernel id
+-		 */
+-		int thread_id = syscall(SYS_gettid);	/* perf issue ? */
+-
+-		snprintf(prefixed, MAX_PRINT_SIZE,
+-			 "%s [%d] %s:%s:%d: %s",
+-			 trace_level_strings[level], thread_id, prefix, func,
+-			 line, raw);
+-		to_print = prefixed;
+-	} else {
+-		to_print = raw;
++		n = snprintf(msg, sizeof(msg), "%s [%d] %s:%s:%d: ",
++			trace_level_strings[level], thread_id, prefix,
++			function, line);
++		if (n < 0)
++			return;
+ 	}
+ 
+-	fprintf(stdout, "%s", to_print);
+-
+-	log_to_file(to_print);
++	if ((size_t)n < sizeof(msg)) {
++		va_start(ap, fmt);
++		n = vsnprintf(msg + n, sizeof(msg) - n, fmt, ap);
++		va_end(ap);
++		if (n < 0)
++			return;
++	}
+ 
+-	return err;
++	fprintf(stdout, "%s", msg);
++	log_to_file(msg);
+ }
+ 
+ #if (defined(DEBUGLEVEL_3) || defined(DEBUGLEVEL_true) || defined(DEBUGLEVEL_4))
+diff --git a/public/teec_trace.h b/public/teec_trace.h
+index 28e290c..f75358f 100644
+--- a/public/teec_trace.h
++++ b/public/teec_trace.h
+@@ -91,12 +91,12 @@ extern "C" {
+ #define __PRINTFLIKE(__fmt, __varargs) __attribute__\
+ 	((__format__(__printf__, __fmt, __varargs)))
+ 
+-int _dprintf(const char *function, int flen, int line, int level,
+-	     const char *prefix, const char *fmt, ...) __PRINTFLIKE(6, 7);
++void _dprintf(const char *function, int line, int level, const char *prefix,
++	      const char *fmt, ...) __PRINTFLIKE(5, 6);
+ 
+ #define dprintf(level, x...) do { \
+ 		if ((level) <= DEBUGLEVEL) { \
+-			_dprintf(__func__, strlen(__func__), __LINE__, level, \
++			_dprintf(__func__, __LINE__, level, \
+ 				 BINARY_PREFIX, x); \
+ 		} \
+ 	} while (0)
+@@ -118,7 +118,7 @@ int _dprintf(const char *function, int flen, int line, int level,
+ 
+ #define dprintf_raw(level, x...) do { \
+ 		if ((level) <= DEBUGLEVEL) \
+-			_dprintf(0, 0, 0, (level), BINARY_PREFIX, x); \
++			_dprintf(0, 0, (level), BINARY_PREFIX, x); \
+ 	} while (0)
+ 
+ #define EMSG_RAW(fmt, ...)   dprintf_raw(TRACE_ERROR, fmt, ##__VA_ARGS__)
+-- 
+2.7.4
+

--- a/recipes-security/optee/optee-client-imx_git.bb
+++ b/recipes-security/optee/optee-client-imx_git.bb
@@ -13,7 +13,9 @@ SRC_URI = "${OPTEE_CLIENT_SRC};branch=${SRCBRANCH}"
 SRCREV = "09b69afa5e9e74aac39e383d74f14b4d61c90476" 
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
-SRC_URI_append = " file://tee-supplicant.service"
+
+SRC_URI_append = " file://0001-libteec-refactor-_dprintf.patch \
+                   file://tee-supplicant.service"
 
 S = "${WORKDIR}/git"
 SYSTEMD_SERVICE_${PN} = "tee-supplicant.service"

--- a/recipes-security/optee/optee-test-imx/0001-regression-4011-correct-potential-overflow.patch
+++ b/recipes-security/optee/optee-test-imx/0001-regression-4011-correct-potential-overflow.patch
@@ -1,0 +1,72 @@
+Upstream-Status: Backport
+
+Signed-off-by: Peter Griffin <peter.griffin@linaro.org>
+---
+From 0953bf0abb08fb98d24b7966001171a707fbb9b9 Mon Sep 17 00:00:00 2001
+From: Etienne Carriere <etienne.carriere@linaro.org>
+Date: Fri, 21 Dec 2018 15:36:25 +0100
+Subject: [PATCH] regression 4011: correct potential overflow
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fix issues reported by GCC 8.2.0.
+
+build/optee_test/host/xtest/regression_4000.c: In function ‘xtest_tee_test_4011’:
+build/optee_test/host/xtest/regression_4000.c:5029:3: error: ‘memmove’ pointer overflow between offset [0, 8] and size [4294967295, 2147483647] accessing array ‘tmp’ with type ‘uint8_t[1024]’ {aka ‘unsigned char[1024]’} [-Werror=array-bounds]
+   memmove(tmp + n + i, tmp + m, tmp_size - m);
+   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+build/optee_test/host/xtest/regression_4000.c:4927:10: note: array ‘tmp’ declared here
+  uint8_t tmp[1024];
+          ^~~
+build/optee_test/host/xtest/regression_4000.c:5029:3: error: ‘memmove’ specified size 4294967295 exceeds maximum object size 2147483647 [-Werror=stringop-overflow=]
+   memmove(tmp + n + i, tmp + m, tmp_size - m);
+   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+cc1: all warnings being treated as errors
+
+Reported-by: Simon Hughes <simon.hughes@arm.com>
+Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>
+Reviewed-by: Jens Wiklander <jens.wiklander@linaro.org>
+---
+ host/xtest/regression_4000.c | 16 +++++++++++++---
+ 1 file changed, 13 insertions(+), 3 deletions(-)
+
+diff --git a/host/xtest/regression_4000.c b/host/xtest/regression_4000.c
+index 766aad2..205a226 100644
+--- a/host/xtest/regression_4000.c
++++ b/host/xtest/regression_4000.c
+@@ -5018,18 +5018,28 @@ static void xtest_tee_test_4011(ADBG_Case_t *c)
+ 				out, out_size, tmp, &tmp_size)))
+ 			goto out;
+ 
++		if (!ADBG_EXPECT_COMPARE_UNSIGNED(c, tmp_size, <=, sizeof(tmp)))
++			goto out;
++
+ 		/* 4.1 */
+-		for (n = 0; n < tmp_size; n++)
++		for (n = 0; n < tmp_size - i; n++)
+ 			if (tmp[n] == 0xff)
+ 				break;
++
++		/* Shall find at least a padding start before buffer end */
++	        if (!ADBG_EXPECT_COMPARE_UNSIGNED(c, n, <, tmp_size - i - 1))
++			goto out;
++
+ 		for (m = n + 1; m < tmp_size; m++)
+ 			if (tmp[m] != 0xff)
+ 				break;
++
+ 		/* 4.2 */
+ 		memmove(tmp + n + i, tmp + m, tmp_size - m);
++
+ 		/* 4.3 */
+-		for (n = n + tmp_size - m + i; n < tmp_size; n++)
+-			tmp[n] = 0;
++		n = n + i + tmp_size - m;
++		memset(tmp + n, 0, tmp_size - n);
+ 
+ 		/* 5 */
+ 		out_size = sizeof(out);
+-- 
+2.7.4
+

--- a/recipes-security/optee/optee-test-imx/0001-xtest-prevent-unexpected-build-warning-with-strncpy.patch
+++ b/recipes-security/optee/optee-test-imx/0001-xtest-prevent-unexpected-build-warning-with-strncpy.patch
@@ -1,0 +1,66 @@
+Upstream-Status: Backport
+
+Signed-off-by: Peter Griffin <peter.griffin@linaro.org>
+---
+From 493574ad1f4f56dd63097a652b87c25c507ce99c Mon Sep 17 00:00:00 2001
+From: Etienne Carriere <etienne.carriere@linaro.org>
+Date: Fri, 21 Dec 2018 15:36:00 +0100
+Subject: [PATCH] xtest: prevent unexpected build warning with strncpy
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This change modifies adbg_run.c to prevent a false positive
+warning reported by GCC 8.2 on usage of strncpy():
+
+    build/optee_test/host/xtest/adbg/src/adbg_run.c: In function ‘Do_ADBG_AppendToSuite’:
+    build/optee_test/host/xtest/adbg/src/adbg_run.c:103:3: error: ‘strncpy’ specified bound depends on the length of the source argument [-Werror=stringop-overflow=]
+       strncpy(p, Source_p->SuiteID_p, size);
+       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    build/optee_test/host/xtest/adbg/src/adbg_run.c:88:9: note: length computed here
+      size = strlen(Source_p->SuiteID_p);
+             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+    cc1: all warnings being treated as errors
+
+From [1]:
+  Using strncpy Safely
+  In general, it is not possible to avoid string truncation by strncpy
+  except by sizing the destination to be at least a byte larger than
+  the length of the source string. With that approach, however, using
+  strncpy becomes unnecessary and the function can be avoided in favor
+  of other APIs such as strcpy or (less preferably) memcpy. Much has
+  been written about the problems with strncpy and we recommend to
+  avoid it whenever possible. It is, however, worth keeping in mind
+  that unlike other standard string-handling functions, strncpy always
+  writes exactly as many characters as specified by the third argument;
+  if the source string is shorter, the function fills the remaining
+  bytes with NULs.
+
+This change prefers using a snprintf() as used in the alternate
+instruction block of the strncpy() call.
+
+[1] https://developers.redhat.com/blog/2018/05/24/detecting-string-truncation-with-gcc-8/
+
+Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>
+Signed-off-by: Simon Hughes <simon.hughes@arm.com>
+Reviewed-by: Jens Wiklander <jens.wiklander@linaro.org>
+---
+ host/xtest/adbg/src/adbg_run.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/host/xtest/adbg/src/adbg_run.c b/host/xtest/adbg/src/adbg_run.c
+index 406e429..2739db5 100644
+--- a/host/xtest/adbg/src/adbg_run.c
++++ b/host/xtest/adbg/src/adbg_run.c
+@@ -100,7 +100,7 @@ int Do_ADBG_AppendToSuite(
+ 		snprintf(p, size, "%s+%s", Dest_p->SuiteID_p,
+ 			 Source_p->SuiteID_p);
+ 	else
+-		strncpy(p, Source_p->SuiteID_p, size);
++		snprintf(p, size, "%s", Source_p->SuiteID_p);
+ 	free((void *)Dest_p->SuiteID_p);
+ 	Dest_p->SuiteID_p = p;
+ 
+-- 
+2.7.4
+

--- a/recipes-security/optee/optee-test-imx_git.bb
+++ b/recipes-security/optee/optee-test-imx_git.bb
@@ -14,6 +14,10 @@ OPTEE_TEST_SRC ?= "git://source.codeaurora.org/external/imx/imx-optee-test.git;p
 SRC_URI = "${OPTEE_TEST_SRC};branch=${SRCBRANCH}"
 SRCREV = "b7b6c4d4af9607a3987988ae62b0957e659a32ef" 
 
+SRC_URI_append = " file://0001-xtest-prevent-unexpected-build-warning-with-strncpy.patch \
+                   file://0001-regression-4011-correct-potential-overflow.patch \
+"
+
 S = "${WORKDIR}/git"
 
 do_compile () {


### PR DESCRIPTION
Add some backported fixes required to build with gcc8. Also set optee package name in the SoC imx8mqevk.conf